### PR TITLE
Fix unsubscribe_client_context_change exception

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -9,6 +9,11 @@ Release Notes
 
 .. release:: upcoming
 
+    .. change:: fixed
+
+        Fix unsubscribe_client_context_change exception
+
+
 .. release:: 1.0.1
     :date: 2022-08-01
 

--- a/source/ftrack_connect_pipeline_maya/client/asset_manager.py
+++ b/source/ftrack_connect_pipeline_maya/client/asset_manager.py
@@ -58,4 +58,4 @@ class MayaQtAssetManagerClientWidgetMixin(
         ).dockCloseEventTriggered()
         self.logger.debug('closing qt client')
         # Unsubscribe to context change events
-        self.unsubscribe_client_context_change()
+        self.unsubscribe_host_context_change()

--- a/source/ftrack_connect_pipeline_maya/client/publish.py
+++ b/source/ftrack_connect_pipeline_maya/client/publish.py
@@ -53,4 +53,4 @@ class MayaQtPublisherClientWidgetMixin(
         super(MayaQtPublisherClientWidgetMixin, self).dockCloseEventTriggered()
         self.logger.debug('closing qt client')
         # Unsubscribe to context change events
-        self.unsubscribe_client_context_change()
+        self.unsubscribe_host_context_change()


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-3mek9xn

- [X] The PR contains update to the release notes.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [X] Linux.


## Changes

Fixed bug where an invalid call to unsubscribe_client_context_change was made in the widget hide

## Test

Open Maya and open+close Publisher client, no exception should be thrown in console
            